### PR TITLE
Correct the way of running monolithic code

### DIFF
--- a/graphql.js
+++ b/graphql.js
@@ -28,10 +28,12 @@ class StateExecution {
 
         return new Promise((resolve, reject) => {
             const _modulePath = `${path.join(_thisFunction.executionPath, stateObject.Run)}`
-            const fModule = __non_webpack_require__(`${_thisFunction.executionName}`)
             let _stateFunction = __non_webpack_require__(_modulePath).handler
-            if (process.env.MONOLITHIC_CODE == "YES" && fModule[stateObject.Run]) {
-                _stateFunction = fModule[stateObject.Run].handler
+            if (process.env.MONOLITHIC_CODE !== "YES") {
+                const fModule = __non_webpack_require__(`${_thisFunction.executionName}`)
+                if (fModule[stateObject.Run]) {
+                    _stateFunction = fModule[stateObject.Run].handler
+                }
             }
             _thisFunction.verbose(`StateExecution:RUN_CONTEXT name = ${stateObject.Run} args =`, JSON.stringify(event.args))
             _stateFunction(event, context, function (err, data) {


### PR DESCRIPTION
Minimal consuming time when running in monolithic mode
For more information about this commit: when running on AWS lambda it took approximately 5 seconds to load the dependency from Lambda layer (non monolithic mode) while MONOLITHIC_CODE flag is YES. This cost me much for the cold boot time.