### PR TITLE
Avoid issue 'ResourceConflictException'

### DIFF
--- a/graphql.js
+++ b/graphql.js
@@ -28,10 +28,12 @@ class StateExecution {
 
         return new Promise((resolve, reject) => {
             const _modulePath = `${path.join(_thisFunction.executionPath, stateObject.Run)}`
-            const fModule = __non_webpack_require__(`${_thisFunction.executionName}`)
             let _stateFunction = __non_webpack_require__(_modulePath).handler
-            if (process.env.MONOLITHIC_CODE == "YES" && fModule[stateObject.Run]) {
-                _stateFunction = fModule[stateObject.Run].handler
+            if (process.env.MONOLITHIC_CODE !== "YES") {
+                const fModule = __non_webpack_require__(`${_thisFunction.executionName}`)
+                if (fModule[stateObject.Run]) {
+                    _stateFunction = fModule[stateObject.Run].handler
+                }
             }
             _thisFunction.verbose(`StateExecution:RUN_CONTEXT name = ${stateObject.Run} args =`, JSON.stringify(event.args))
             _stateFunction(event, context, function (err, data) {

--- a/simplify.js
+++ b/simplify.js
@@ -490,12 +490,36 @@ const createOrUpdateFunction = function (options) {
                     consoleWithMessage(`${opName}-UpdateFunctionConfig`, `${functionConfig.FunctionName.truncate(50)}`, err);
                     const unusedProps = ["Code", "Publish", "Tags"]
                     unusedProps.forEach(function (k) { delete params[k] })
-                    adaptor.updateFunctionConfiguration(params, function (err) {
+                    adaptor.updateFunctionConfiguration(params, function (err, data) {
                         if (err) {
                             reject(err)
                         } else {
-                            consoleWithMessage(`${opName}-UpdateFunctionConfig`, `${CDONE}(OK)${CRESET}`);
-                            tryToUpdateFunctionCode(options, resolve, reject);
+                            adaptor.waitFor('functionUpdated', { FunctionName: data.FunctionArn }, function(err, data) {
+                                if (err) {
+                                    reject(err);
+                                } else {
+                                    consoleWithMessage(`${opName}-UpdateFunctionConfig`, `${CDONE}(OK)${CRESET}`);
+                                    adaptor.updateFunctionCode({
+                                         FunctionName: functionConfig.FunctionName,
+                                         S3Bucket: bucketName,
+                                         S3Key: bucketKey
+                                     }, function (err, data) {
+                                         if (err) {
+                                             consoleWithMessage(`${opName}-UpdateFunctionCode`, `${CERROR}(ERROR)${CRESET} ${err}`);
+                                             reject(err)
+                                         } else {
+                                             adaptor.waitFor('functionUpdated', { FunctionName: data.FunctionArn }, function(err, data) {
+                                                if (err) {
+                                                    reject(err);
+                                                } else {
+                                                     consoleWithMessage(`${opName}-UpdateFunctionCode`, `${CDONE}(OK)${CRESET}`);
+                                                     resolve(data)
+                                                }
+                                             });
+                                         }
+                                     });
+                                }
+                            });
                         }
                     });
                 } else {
@@ -503,8 +527,18 @@ const createOrUpdateFunction = function (options) {
                     function retryCreateFunction() {
                         consoleWithMessage(`${opName}-CreateFunction`, `${functionConfig.FunctionName.truncate(50)}`);
                         adaptor.createFunction(params, function (err, data) {
-                            if (++index > creationTimeout || !err) {
-                                index > creationTimeout ? reject(`Create Function Timeout with (Error): ${err}`) : resolve({ ...data })
+                            if (++index > creationTimeout) {
+                                reject(`Create Function Timeout with (Error): ${err}`)
+                            } else if (!err) {
+                                resolve({ ...data });
+                                adaptor.waitFor('functionActive', { FunctionName: data.FunctionArn }, function(err, data) {
+                                    if (err) {
+                                        reject(err);
+                                    } else {
+                                        consoleWithMessage(`${opName}-CreateFunction`, `${CDONE}(OK)${CRESET}`);
+                                        resolve(data)
+                                    }
+                                });
                             } else {
                                 setTimeout(() => retryCreateFunction(), 1000)
                             }
@@ -513,8 +547,14 @@ const createOrUpdateFunction = function (options) {
                     retryCreateFunction()
                 }
             } else {
-                consoleWithMessage(`${opName}-CreateFunction`, `${CDONE}(OK)${CRESET}`);
-                resolve(data)
+                adaptor.waitFor('functionActive', { FunctionName: data.FunctionArn }, function(err, data) {
+                    if (err) {
+                        reject(err);
+                    } else {
+                        consoleWithMessage(`${opName}-CreateFunction`, `${CDONE}(OK)${CRESET}`);
+                        resolve(data)
+                    }
+                });
             }
         })
     })
@@ -531,8 +571,14 @@ const updateFunctionConfiguration = function (options) {
                 consoleWithMessage(`${opName}-UpdateFunctionConfig`, `${CERROR}(ERROR)${CRESET} ${err}`);
                 reject(err)
             } else {
-                consoleWithMessage(`${opName}-UpdateFunctionConfig`, `${CDONE}(OK)${CRESET}`);
-                resolve(data)
+                adaptor.waitFor('functionUpdated', { FunctionName: data.FunctionArn }, function(err, data) {
+                    if (err) {
+                        reject(err);
+                    } else {
+                        consoleWithMessage(`${opName}-UpdateFunctionConfig`, `${CDONE}(OK)${CRESET}`);
+                        resolve(data)
+                    }
+                });
             }
         })
     })

--- a/simplify.js
+++ b/simplify.js
@@ -566,7 +566,7 @@ const updateFunctionConfiguration = function (options) {
     return new Promise(function (resolve, reject) {
         const unusedProps = ["Code", "Publish", "Tags"]
         unusedProps.forEach(function (k) { delete functionConfig[k] })
-        adaptor.waitFor('functionActive', { FunctionName: data.FunctionArn }, function(err, data) {
+        adaptor.waitFor('functionActive', { FunctionName: functionConfig.FunctionName }, function(err, data) {
             if (err) {
                 reject(err);
             } else {


### PR DESCRIPTION
AWS response result right after they recieve request. This sometimes cause error while the update operation on current Lambda function is still in progress, there are multiple update request sent. The SDK provides a way to wait for the operation done, named waitFor to solve the problem update lambda multiple times.